### PR TITLE
retry with smaller batch inserts on failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM semtech/mu-ruby-template:2.10.0-ruby2.5
 MAINTAINER Aad Versteden <madnificent@gmail.com>
 # see https://github.com/mu-semtech/mu-ruby-template for more info
+ENV BATCH_SIZE 12000
+ENV MIN_BATCH_SIZE 100

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM semtech/mu-ruby-template:2.10.0-ruby2.5
 MAINTAINER Aad Versteden <madnificent@gmail.com>
 # see https://github.com/mu-semtech/mu-ruby-template for more info
 ENV BATCH_SIZE 12000
-ENV MIN_BATCH_SIZE 100
+ENV MINIMUM_BATCH_SIZE 100

--- a/README.md
+++ b/README.md
@@ -105,3 +105,10 @@ available in `/data/migrations`. The migrations may be grouped in subfolders.
 The migration will be ran when the mu-migrations-service starts up,
 and output about the status of the ran migrations will be written to
 the database for later inspection.
+
+## Configuration
+
+The migration service supports the following environment variables (+ the ones inherited from the [ruby template](https://github.com/mu-semtech/mu-ruby-template)):
+
+- `BATCH_SIZE`: amount of triples to insert in one go (default: 12000)
+- `MIN_BATCH_SIZE`: if the batch size drops below this number due to batch size resizing on error, the service will stop with an error. (default: 100)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,16 @@ the database for later inspection.
 
 ## Configuration
 
-The migration service supports the following environment variables (+ the ones inherited from the [ruby template](https://github.com/mu-semtech/mu-ruby-template)):
+The migration service supports configuration via environment variables.
+
+### Large datasets and batch size
+Triple stores typically can only handle a certain amount of triples to be ingested per request. The migration service supports batching to split of large datasets in multiple requests. This can be configured with the `BATCH_SIZE` environment variable. If an error occurs during batch ingestion the batch size will be halved and the request retried until `MINIMUM_BATCH_SIZE` is reached. At this point an error will be thrown. 
+
+To make sure a dataset is loaded completely it will first be ingested into a temporary graph, on success the contents will be added to the target graph with a SPARQL Graph query. 
+
 
 - `BATCH_SIZE`: amount of triples to insert in one go (default: 12000)
-- `MIN_BATCH_SIZE`: if the batch size drops below this number due to batch size resizing on error, the service will stop with an error. (default: 100)
+- `MINIMUM_BATCH_SIZE`: if the batch size drops below this number the service will stop with an error. (default: 100)
+
+### General configuration
+This microservice is based on the [mu-ruby template](https://github.com/mu-semtech/mu-ruby-template) and supports the environment variables documented in its [README](https://github.com/mu-semtech/mu-ruby-template#configuration).

--- a/web.rb
+++ b/web.rb
@@ -84,12 +84,26 @@ class Migration
   end
 
   private
-  def batch_insert(data, graph:, batch_size: 3000)
+  def batch_insert(data, graph:, batch_size: 12000)
     log.info("dataset of #{data.size} triples will be inserted in batches of #{batch_size} triples")
     temp_graph = "http://migrations.mu.semte.ch/#{SecureRandom.uuid}"
+    from = 0
+    data = data.to_a
     begin
-      data.each_slice(batch_size) do |slice|
-        sparql_client.insert_data(slice, graph: temp_graph)
+      while from < data.size do
+        slice = data.slice(from, batch_size)
+        log.info("inserting triples #{from} to #{[from + batch_size, data.size].min}")
+        begin
+          sparql_client.insert_data(slice, graph: temp_graph)
+          from = from + batch_size
+        rescue => e
+          log.warn "error loading triples (#{e.message}), retrying with a smaller batch size"
+          batch_size = batch_size / 2
+          if batch_size < 100
+            log.error "batch size has dropped below 100, no longer retrying"
+            raise e
+          end
+        end
       end
       update("ADD <#{temp_graph}> TO <#{graph}>")
     rescue => e

--- a/web.rb
+++ b/web.rb
@@ -84,7 +84,7 @@ class Migration
   end
 
   private
-  def batch_insert(data, graph:, batch_size: 12000)
+  def batch_insert(data, graph:, batch_size: ENV['BATCH_SIZE'].to_i)
     log.info("dataset of #{data.size} triples will be inserted in batches of #{batch_size} triples")
     temp_graph = "http://migrations.mu.semte.ch/#{SecureRandom.uuid}"
     from = 0
@@ -99,7 +99,7 @@ class Migration
         rescue => e
           log.warn "error loading triples (#{e.message}), retrying with a smaller batch size"
           batch_size = batch_size / 2
-          if batch_size < 100
+          if batch_size < ENV['MINIMUM_BATCH_SIZE'].to_i
             log.error "batch size has dropped below 100, no longer retrying"
             raise e
           end


### PR DESCRIPTION
The current migration service can sometimes fail to load a TTL file for various reasons, this PR makes the batch insertion both faster where possible and more defensive.

The default batch size was increased to 12.000 and logic was introduced to retry with smaller batch sizes on failure (stopping when batch size drops below 100triples). 