### PR TITLE
bump ruby-template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-ruby-template:2.10.0-ruby2.5
+FROM semtech/mu-ruby-template:2.11.0-ruby2.5
 MAINTAINER Aad Versteden <madnificent@gmail.com>
 # see https://github.com/mu-semtech/mu-ruby-template for more info
 ENV BATCH_SIZE 12000

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Added at 2019-12-16 10:37:51 +0100 by nielsv:
+gem "rdf-turtle", "~> 3.0"


### PR DESCRIPTION
latest ruby template only includes basic gems, migrations relies on rdf-turtle and
should provide that itself.

This pull request is a preparation for mu-auth-sudo, which is in sync with the latest template