### PR TITLE
make db up check mu-auth compatible

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -188,10 +188,10 @@ end
 
 def is_database_up?
   begin
-    location = URI(ENV['MU_SPARQL_ENDPOINT'])
-    response = Net::HTTP.get_response( location )
-    return response.is_a? Net::HTTPSuccess
-  rescue Errno::ECONNREFUSED
+    query_sudo("ASK { ?s ?p ?o }")
+    return true
+  rescue StandardError => e
+    logger.debug e
     return false
   end
 end

--- a/web.rb
+++ b/web.rb
@@ -188,10 +188,10 @@ end
 
 def is_database_up?
   begin
-    query_sudo("ASK { ?s ?p ?o }")
+    Mu::AuthSudo.query("ASK { ?s ?p ?o }")
     return true
   rescue StandardError => e
-    logger.debug e
+    log.warn e
     return false
   end
 end


### PR DESCRIPTION
mu-auth doesn't return a 200 status if no query is provided. This should fix #10 . This does not check the actual result for the query because even if the endpoint is empty (and returns false), it's still up if it correctly returns a response :).

Note:  this needs testing