### PR TITLE
change count batch size to 10.000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ LABEL maintainer="Aad Versteden <madnificent@gmail.com>"
 # see https://github.com/mu-semtech/mu-ruby-template for more info
 ENV BATCH_SIZE 12000
 ENV MINIMUM_BATCH_SIZE 100
-ENV COUNT_BATCH_SIZE 12000
+ENV COUNT_BATCH_SIZE 10000

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ Used prefix: `muMigr: <http://mu.semte.ch/vocabularies/migrations/>`
 The migration service supports configuration via environment variables.
 - `BATCH_SIZE`: amount of triples to insert in one go for a Turtle migration (default: 12000)
 - `MINIMUM_BATCH_SIZE`: if the batch size drops below this number the service will stop with an error. (default: 100)
-- `COUNT_BATCH_SIZE`: number of executed migrations to retrieve from the database in one go (default: 12000)
+- `COUNT_BATCH_SIZE`: number of executed migrations to retrieve from the database in one go (default: 10000). 
+*NOTE*: Make sure this is lower or equal to the maximum number of rows returned by the SPARQL endpoint.
 
 This microservice is based on the [mu-ruby template](https://github.com/mu-semtech/mu-ruby-template) and supports the environment variables documented in its [README](https://github.com/mu-semtech/mu-ruby-template#configuration).
 


### PR DESCRIPTION
This brings the default more in line with the default limit of rows returned by virtuoso in a mu.semte.ch project. If COUNT_BATCH_SIZE is higher than what's configured in virtuoso not all migrations logged in the DB are returned correctly.